### PR TITLE
fix variations translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  
 ## [Unreleased]
 
+### Fixed
+- `variations` translation
+
 ## [0.2.1] - 2021-09-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
+    "watch": "tsc -w",
     "build": "tsc",
     "lint": "yarn eslint ./src --cache --ext ts --config .eslintrc",
     "test": "jest"


### PR DESCRIPTION
#### What problem is this solving?

The variations field is not being translated by the biggy API. It was causing a bug where the SKUSelector options were unavailable

The back end team will be busy for a while, so I'm using the `textAttributes` field to translate it

#### How should this be manually tested?

[Broken workspace](https://hiago2--quebramar.myvtex.com/)
![image](https://user-images.githubusercontent.com/40380674/135514340-af459a89-51fb-44ae-9f92-a047a8596861.png)

[Fixed](https://hiago2--quebramar.myvtex.com/)
![image](https://user-images.githubusercontent.com/40380674/135514490-1eb61195-7430-4bf3-b016-ea46e969104c.png)


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
