### PR TITLE
Feature/get spot price from search product

### DIFF
--- a/src/__tests__/mock/biggyProduct.ts
+++ b/src/__tests__/mock/biggyProduct.ts
@@ -285,6 +285,8 @@ export const biggyProductMock: BiggySearchProduct = {
       ],
       oldPriceText: '$1,000.50',
       priceText: '$600.30',
+      spotPrice: 500.3,
+      spotPriceText: '$500.30',
     },
   ],
   link: 'tank-top',

--- a/src/__tests__/mock/vtexProduct.ts
+++ b/src/__tests__/mock/vtexProduct.ts
@@ -426,7 +426,7 @@ export const vtexProductMock: SearchProduct = {
             ListPrice: 1000.5,
             Tax: 0,
             taxPercentage: 0,
-            spotPrice: 600.3,
+            spotPrice: 500.3,
             PriceWithoutDiscount: 1000.5,
             RewardValue: 0,
             PriceValidUntil: '2022-06-16T19:20:58Z',

--- a/src/convertSKU.ts
+++ b/src/convertSKU.ts
@@ -76,6 +76,7 @@ const getSellersIndexedByApi = (product: BiggySearchProduct, sku: BiggySearchSKU
     (seller: BiggySeller): Seller => {
       const price = getFirstNonNullable<number | undefined>([seller.price, sku.price, product.price]) ?? 0
       const oldPrice = getFirstNonNullable<number | undefined>([seller.oldPrice, sku.oldPrice, product.oldPrice]) ?? 0
+      // if spot price does not exist, it means that there is no spot price promotion, aka spotPrice == price
       const spotPrice =
         getFirstNonNullable<number | undefined>([seller.spotPrice, sku.spotPrice, product.spotPrice]) ?? price
 
@@ -99,6 +100,7 @@ const getSellersIndexedByApi = (product: BiggySearchProduct, sku: BiggySearchSKU
 
 const getSellersIndexedByXML = (product: BiggySearchProduct): Seller[] => {
   const { price, oldPrice, installment, stock } = product
+  // if spot price does not exist, it means that there is no spot price promotion, aka spotPrice == price
   const spotPrice = product.spotPrice ?? price
 
   const commertialOffer = buildCommertialOffer(price, oldPrice, spotPrice, stock, [], installment, product.tax)

--- a/src/typings/global.ts
+++ b/src/typings/global.ts
@@ -13,6 +13,7 @@ declare global {
     link: string
     oldPrice: number
     price: number
+    spotPrice?: number
     stock: number
     brand: string
     brandId: string
@@ -49,6 +50,7 @@ declare global {
     extraInfo: BiggyExtraInfo
     oldPriceText: string
     priceText: string
+    spotPriceText?: string
   }
 
   interface BiggyExtraInfo {
@@ -109,6 +111,8 @@ declare global {
     oldPriceText?: string
     price?: number
     priceText?: string
+    spotPrice?: number
+    spotPriceText?: string
     measurementUnit?: string
     unitMultiplier?: number
     link?: string
@@ -163,6 +167,7 @@ declare global {
     name: string
     oldPrice?: number
     price?: number
+    spotPrice?: number
     stock?: number
     tax: number
     default: boolean

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,14 +35,6 @@ export const getMaxAndMinForAttribute = (offers: CommertialOffer[], attribute: '
   )
 }
 
-export const getSpotPrice = (sellingPrice: number, installments: SearchInstallment[]) => {
-  const spotPrice: number | undefined = installments.find(({ NumberOfInstallments, Value }: any) => {
-    return NumberOfInstallments === 1 && Value < sellingPrice
-  })?.Value
-
-  return spotPrice ?? sellingPrice
-}
-
 export const getFirstNonNullable = <T>(arr: T[]): T | undefined => {
   return arr.find((el) => el !== null && typeof el !== 'undefined')
 }


### PR DESCRIPTION
#### What problem is this solving?

From the moment that we start indexing spotPrice, we no longer have to calculate it in this project.
This PR updates the convertSKU function to get the spotPrice directly from the searchProduct, instead of calculating it.
