### PR TITLE
fix: yarn publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
  
 ## [Unreleased]
+### Added
+- Add "files" field to `package.json` to allow `yarn publish`
 
 ## [1.1.0] - 2021-10-25
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/vtexis-compatibility-layer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Compatibility layer between intelligent search and VTEX",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -16,6 +16,7 @@
     "search",
     "is"
   ],
+  "files": ["lib"],
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/vtexis-compatibility-layer",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Compatibility layer between intelligent search and VTEX",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -16,7 +16,9 @@
     "search",
     "is"
   ],
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
#### What problem is this solving?
When publishing this package with `yarn publish`, npm only packs the `lib/index.js` file. This is because the `files` field is lacking. 

This PR adds this missing field so we can publish this lib using yarn publish`
 
