### PR TITLE
use labelkey instead of original key when converting the specifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Use `labelKey` instead of `originalKey` when converting specifications.
+
 ## [1.2.5] - 2022-12-08
 
 ### Fixed


### PR DESCRIPTION
#### What problem is this solving?

[Jira](https://vtex-dev.atlassian.net/browse/IS-4187)

We are filling the specifiction field `name` with the `originalKey`(original languange) instead of the `labelKey`(translated). This was causing problems during the translation on `vtex.search-resolver`

#### How should this be manually tested?

<details>
  <summary>Before</summary>

  
  ```
curl --request POST \
  --url 'https://master--itccwhirlpool.myvtex.com/_v/private/graphql/v1?locale=en-US&__bindingAddress=ff.whirlpoolgroup.it%2F' \
  --header 'Content-Type: application/json' \
  --header 'Cookie: VtexWorkspace=master%3A-' \
  --header 'VtexIdclientAutCookie: ' \
  --data '{"query":"query{\n products(collection:\"138\") @context(provider: \"vtex.search-graphql\"){\n productId,\n productName,\n brand,\n link,\n linkText,\n metaTagDescription,\n description,\n properties{\n name\n originalName\n }\n productClusters{\n name\n }\n clusterHighlights{\n name\n }\n categoryTree {\n name\n }\n items {\n itemId\n name\n }\n }\n }","variables":{}}'
  ```
  ![image](https://user-images.githubusercontent.com/40380674/207656780-70d4d896-36e4-404a-a9cf-1f9f61c300a0.png)
</details>


<details>
  <summary>After</summary>

  
  ```
curl --request POST \
  --url 'https://hiago--itccwhirlpool.myvtex.com/_v/private/graphql/v1?locale=en-US&__bindingAddress=ff.whirlpoolgroup.it%2F' \
  --header 'Content-Type: application/json' \
  --header 'Cookie: VtexWorkspace=master%3A-' \
  --header 'VtexIdclientAutCookie: ' \
  --data '{"query":"query{\n products(collection:\"138\") @context(provider: \"vtex.search-graphql\"){\n productId,\n productName,\n brand,\n link,\n linkText,\n metaTagDescription,\n description,\n properties{\n name\n originalName\n }\n productClusters{\n name\n }\n clusterHighlights{\n name\n }\n categoryTree {\n name\n }\n items {\n itemId\n name\n }\n }\n }","variables":{}}'
  ```
  
![image](https://user-images.githubusercontent.com/40380674/207657095-1328680e-c7ba-41fd-9afc-5774b5feecc3.png)

</details>

[Workspace](https://hiago--itccwhirlpool.myvtex.com/_v/segment/admin-login/v1/login?returnUrl=%2F%3F)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
