### PR TITLE
Bugfix/refact specification groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Bug where the specifications were converted to an empty array.
+
+## [1.2.11] - 2022-12-14
+
+### Fixed
+
 - The `converISProduct` throws an error due to an inconsistency in the specifications format.
 
 ## [1.2.7] - 2022-12-14

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/vtexis-compatibility-layer",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/vtexis-compatibility-layer",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Compatibility layer between intelligent search and VTEX",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
#### What problem is this solving?

Currently, we use the product object as a dictionary to store specifications and specification groups.

For example, let's say that we have the following case:

```json
{
	"originalName": "Especificações",
	"name": "Especificações",
	"specifications": [
		{
			"originalName": "Modelo Veste",
			"name": "Modelo Veste",
			"values": [
				"P"
			]
		}
	]
}
```

The specification group is `"Especificações"` and the list of specifications in this group is `["Modelo Veste"]`

Therefore, the product object will have the following fields

```
product["Especificações"] === ["Modelo Veste"]
product["Modelo veste"] === ["P"]

```

Then we use this info later to build the `specificationGroups` field.

The problem is: What happen when the group name and the specification name are the same? For example

```json
{
					"originalName": "Spedizione",
					"name": "Spedizione",
					"specifications": [
						{
							"originalName": "Spedizione gratuita",
							"name": "Spedizione gratuita",
							"values": []
						}
					]
				}
```
For example

```json
{
	"originalName": "Spedizione",
	"name": "Spedizione",
	"specifications": [
		{
			"originalName": "Spedizione",
			"name": "Spedizione",
			"values": ["Spedizione gratuita"]
		}
	]
}
```
Instead of heaving two fields (one for the specification group and one for the specification) the product will have only one

```
product["Spedizione"] === ["Spedizione gratuita"]
```
This causes a bug where the specification is not found and the specification group is used instead to build the `specificationGroups` field

Before the fix
```json
{
	"specificationGroups": [
		{
			"originalName": "Spedizione",
			"name": "Spedizione",
			"specifications": [
				{
					"originalName": "Spedizione gratuita",
					"name": "Spedizione gratuita",
					"values": []
				}
			]
		}
	]
}
```

After the fix
```json
{
	"specificationGroups": [
		{
			"originalName": "Spedizione",
			"name": "Spedizione",
			"specifications": [
				{
					"originalName": "Spedizione",
					"name": "Spedizione",
					"values": [
						"Spedizione gratuita"
					]
				}
			]
		}
	]
}
```

#### How should this be manually tested?

Before the fix

```
curl --request GET \
  --url 'https://master--bricobravo.myvtex.com/_v/api/intelligent-search/product_search?query=product%3A53992&v=1'
```

After the fix

```
curl --request GET \
  --url 'https://hiago--bricobravo.myvtex.com/_v/api/intelligent-search/product_search?query=product%3A53992&v=1'
```
#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
