### PR TITLE
Add catalogAttributes field to biggysku and attributes field to items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- New fields / conversion from SKU catalogAttributes to item attributes
+
 ## [1.3.0] - 2023-08-15
 
 ### Added

--- a/src/__tests__/mock/biggyProduct.ts
+++ b/src/__tests__/mock/biggyProduct.ts
@@ -186,6 +186,7 @@ export const biggyProductMock: BiggySearchProduct = {
           id: '1',
         },
       ],
+      catalogAttributes: []
     },
     {
       image: 'http://storecomponents.vteximg.com.br/arquivos/ids/155643-55-55/Frame-2.jpg?v=637411555784670000',
@@ -300,6 +301,7 @@ export const biggyProductMock: BiggySearchProduct = {
       oldPriceText: '$1,000.50',
       priceText: '$600.30',
       spotPriceText: '$600.30',
+      catalogAttributes: []
     },
   ],
   link: 'tank-top',

--- a/src/__tests__/mock/vtexProduct.ts
+++ b/src/__tests__/mock/vtexProduct.ts
@@ -376,6 +376,7 @@ export const vtexProductMock: SearchProduct = {
       ],
       kitItems: [],
       attachments: [],
+      attributes: []
     },
     {
       itemId: '4',
@@ -640,6 +641,7 @@ export const vtexProductMock: SearchProduct = {
       ],
       kitItems: [],
       attachments: [],
+      attributes: []
     },
   ],
 }

--- a/src/convertSKU.ts
+++ b/src/convertSKU.ts
@@ -181,7 +181,7 @@ const convertSKU = (product: BiggySearchProduct, indexingType?: IndexingType, tr
 
   const variations = getVariations(sku, product)
 
-  const attributes = convertAttributes(sku.catalogAttributes)
+  const attributes = convertAttributes(sku.catalogAttributes ?? [])
 
   const item: SearchItem & { [key: string]: any } = {
     sellers,

--- a/src/convertSKU.ts
+++ b/src/convertSKU.ts
@@ -154,23 +154,6 @@ const convertImages = (images: BiggyProductImage[], indexingType?: IndexingType)
   return vtexImages
 }
 
-const convertAttributes = (skuCatalogAttributes: BiggySKUCatalogAttribute[]): SearchItemAttribute[] => {
-  const attributes: SearchItemAttribute[] = []
-
-  skuCatalogAttributes.forEach((catalogAttribute) => {
-    const attribute: SearchItemAttribute = {
-      id: catalogAttribute.id,
-      name: catalogAttribute.name,
-      value: catalogAttribute.value,
-      visible: catalogAttribute.visible
-    }
-
-    attributes.push(attribute)
-  })
-
-  return attributes
-}
-
 const convertSKU = (product: BiggySearchProduct, indexingType?: IndexingType, tradePolicy?: string) => (
   sku: BiggySearchSKU
 ): SearchItem & { [key: string]: any } => {
@@ -181,7 +164,7 @@ const convertSKU = (product: BiggySearchProduct, indexingType?: IndexingType, tr
 
   const variations = getVariations(sku, product)
 
-  const attributes = convertAttributes(sku.catalogAttributes ?? [])
+  const attributes = sku.catalogAttributes ?? []
 
   const item: SearchItem & { [key: string]: any } = {
     sellers,

--- a/src/convertSKU.ts
+++ b/src/convertSKU.ts
@@ -154,6 +154,23 @@ const convertImages = (images: BiggyProductImage[], indexingType?: IndexingType)
   return vtexImages
 }
 
+const convertAttributes = (skuCatalogAttributes: BiggySKUCatalogAttribute[]): SearchItemAttribute[] => {
+  const attributes: SearchItemAttribute[] = []
+
+  skuCatalogAttributes.forEach((catalogAttribute) => {
+    const attribute: SearchItemAttribute = {
+      id: catalogAttribute.id,
+      name: catalogAttribute.name,
+      value: catalogAttribute.value,
+      visible: catalogAttribute.visible
+    }
+
+    attributes.push(attribute)
+  })
+
+  return attributes
+}
+
 const convertSKU = (product: BiggySearchProduct, indexingType?: IndexingType, tradePolicy?: string) => (
   sku: BiggySearchSKU
 ): SearchItem & { [key: string]: any } => {
@@ -163,6 +180,8 @@ const convertSKU = (product: BiggySearchProduct, indexingType?: IndexingType, tr
     indexingType === 'XML' ? getSellersIndexedByXML(product) : getSellersIndexedByApi(product, sku, tradePolicy)
 
   const variations = getVariations(sku, product)
+
+  const attributes = convertAttributes(sku.catalogAttributes)
 
   const item: SearchItem & { [key: string]: any } = {
     sellers,
@@ -185,6 +204,7 @@ const convertSKU = (product: BiggySearchProduct, indexingType?: IndexingType, tr
     videos: sku.videos ?? [],
     attachments: [],
     isKit: false,
+    attributes
   }
 
   variations.forEach((variation) => {

--- a/src/typings/global.ts
+++ b/src/typings/global.ts
@@ -124,7 +124,7 @@ declare global {
     attributes: BiggySKUAttribute[]
     sellers: BiggySeller[]
     policies: BiggyPolicy[]
-    catalogAttributes: BiggySKUCatalogAttribute[]
+    catalogAttributes?: BiggySKUCatalogAttribute[]
   }
 
   interface BiggyProductExtraData {

--- a/src/typings/global.ts
+++ b/src/typings/global.ts
@@ -124,6 +124,7 @@ declare global {
     attributes: BiggySKUAttribute[]
     sellers: BiggySeller[]
     policies: BiggyPolicy[]
+    catalogAttributes: BiggySKUCatalogAttribute[]
   }
 
   interface BiggyProductExtraData {
@@ -160,6 +161,13 @@ declare global {
   interface BiggySKUAttribute {
     key: string
     value: string
+  }
+
+  interface BiggySKUCatalogAttribute {
+    id: string
+    name: string
+    value: string
+    visible: boolean
   }
 
   interface BiggyCategoryTree {
@@ -444,6 +452,7 @@ declare global {
       itemId: string
       amount: number
     }>
+    attributes: SearchItemAttribute[]
   }
 
   interface Variation {
@@ -465,6 +474,13 @@ declare global {
 
   interface SearchItemExtended extends SearchItem {
     skuSpecifications?: SkuSpecification[]
+  }
+
+  interface SearchItemAttribute {
+    id: string,
+    name: string,
+    value: string,
+    visible: boolean
   }
 
   interface SkuSpecification {

--- a/src/typings/global.ts
+++ b/src/typings/global.ts
@@ -452,7 +452,7 @@ declare global {
       itemId: string
       amount: number
     }>
-    attributes: SearchItemAttribute[]
+    attributes?: BiggySKUCatalogAttribute[]
   }
 
   interface Variation {
@@ -474,13 +474,6 @@ declare global {
 
   interface SearchItemExtended extends SearchItem {
     skuSpecifications?: SkuSpecification[]
-  }
-
-  interface SearchItemAttribute {
-    id: string,
-    name: string,
-    value: string,
-    visible: boolean
   }
 
   interface SkuSpecification {


### PR DESCRIPTION
#### What problem is this solving?

Adding these fields for the informative sku attributes initiative for hearst.
Basically we added a new field "catalogAttributes" on the skus in the search-api, and we need to transform it to the field "attributes" inside the items for the final product. The objects have the same fields.

#### How should this be manually tested?

[[Workspace](https://tornai--sandboxintegracao.vtexcommercestable.com.br/api/io/_v/api/intelligent-search/product_search/trade-policy/1?q=id:310116800)]

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
<img width="571" alt="Screenshot 2024-02-08 at 11 21 35" src="https://github.com/vtex/vtexis-compatibility-layer/assets/28491720/465dbd8b-c93e-4424-b5cd-3aa60746e915">

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
