### PR TITLE
Translate product properties and specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Translations to product query.
+
 ## [1.5.0] - 2024-02-27
 
 ### Changed

--- a/src/__tests__/mock/documentTranslations.ts
+++ b/src/__tests__/mock/documentTranslations.ts
@@ -1,0 +1,57 @@
+export const translationsMock: TranslatedProperty[] = [
+  {
+    field: 'ProductName',
+    context: '319901251',
+    translation: 'Apple Iphone 11 128gb 6.1" 12mp Purple',
+  },
+  {
+    field: 'CategoryName',
+    context: '14',
+    translation: 'Phones, Smartphones and Smartwatches',
+  },
+  {
+    field: 'CategoryName',
+    context: '356',
+    translation: 'Phones',
+  },
+  {
+    field: 'Description',
+    context: '319901251',
+    translation: `READ WITH ATTENTION:
+      What is a Showcase Device:
+      Showcase device coming directly from the factory, where parts may be exchanged due to launch time and store display, such as:
+      Screen, Battery, Housing, Camera, Power Connector, etc...
+      Direct Warranty with Us of 3 Months for Manufacturing Defects and 7 Days for Return and Exchange
+      We do not guarantee Water Resistance on the Device due to its launch time and the device has already had parts replaced.
+      Battery above 85% percent
+      No Original Box
+      Working FaceID and Clean Icloud
+      Original device tested and working
+      Box Contents:
+      Showcase Apparatus
+      Lightning cable
+      Source Toast
+      Gift Case (According to Stock)
+      Toast Film`,
+  },
+  {
+    field: 'BrandName',
+    context: '2000005',
+    translation: 'Apple',
+  },
+  {
+    field: 'SpecificationName',
+    context: '30',
+    translation: 'Variant_Color',
+  },
+  {
+    field: 'SpecificationValue',
+    context: 'Roxo/Lilas',
+    translation: 'Purple',
+  },
+  {
+    field: 'SkuName',
+    context: '326782298',
+    translation: 'Apple Iphone 11 128gb 6.1" 12mp Purple',
+  },
+]

--- a/src/__tests__/mock/searchDocument.ts
+++ b/src/__tests__/mock/searchDocument.ts
@@ -285,7 +285,7 @@ export const searchDocumentMock: SkuDocument = {
             CategoryId: null,
             IsFilter: false,
             Position: 1,
-            IsStockKeppingUnit: false,
+            IsStockKeppingUnit: true,
             IsActive: true,
             IsSideMenuLinkActive: false,
             IsTopMenuLinkActive: null,

--- a/src/__tests__/mock/searchProduct.ts
+++ b/src/__tests__/mock/searchProduct.ts
@@ -91,7 +91,20 @@ export const searchProductMock: SearchProduct & {
       ],
     },
   ],
-  skuSpecifications: [],
+  skuSpecifications: [
+    {
+      field: {
+        name: 'Variante_Cor',
+        originalName: 'Variante_Cor',
+      },
+      values: [
+        {
+          name: 'Roxo/Lilas',
+          originalName: 'Roxo/Lilas',
+        },
+      ],
+    },
+  ],
   productClusters: [
     {
       id: '23022',

--- a/src/convertSKU.ts
+++ b/src/convertSKU.ts
@@ -187,7 +187,7 @@ const convertSKU = (product: BiggySearchProduct, indexingType?: IndexingType, tr
     videos: sku.videos ?? [],
     attachments: [],
     isKit: false,
-    attributes
+    attributes,
   }
 
   variations.forEach((variation) => {

--- a/src/convertSearchDocument.ts
+++ b/src/convertSearchDocument.ts
@@ -1,11 +1,5 @@
 import { dateToTicks, getPriceRange, getTranslationInfo, objToNameValue } from './utils'
 
-interface TranslatedProperty {
-  field: string
-  context: string
-  translation: string
-}
-
 const searchableClustersFromDocument = (
   ProductClusterNames: Record<string, string>,
   ProductClusterSearchableIds: number[]

--- a/src/convertSearchDocument.ts
+++ b/src/convertSearchDocument.ts
@@ -1,4 +1,10 @@
-import { dateToTicks, getPriceRange, objToNameValue } from './utils'
+import { dateToTicks, getPriceRange, getTranslationInfo, objToNameValue } from './utils'
+
+interface TranslatedProperty {
+  field: string
+  context: string
+  translation: string
+}
 
 const searchableClustersFromDocument = (
   ProductClusterNames: Record<string, string>,
@@ -13,7 +19,11 @@ const searchableClustersFromDocument = (
   return searchableClusters
 }
 
-const categoriesFromDocument = (CategoriesFullPath: string[], CategoriesName: Record<string, string>) => {
+const categoriesFromDocument = (
+  CategoriesFullPath: string[],
+  CategoriesName: Record<string, string>,
+  translations?: TranslatedProperty[]
+) => {
   const categories: string[] = []
 
   CategoriesFullPath.forEach((path) => {
@@ -21,7 +31,9 @@ const categoriesFromDocument = (CategoriesFullPath: string[], CategoriesName: Re
     const ids = path.split('/').filter((value) => value)
 
     ids.forEach((id) => {
-      categoryPath = categoryPath.concat(`${CategoriesName[id]}/`)
+      const translatedName = getTranslationInfo('CategoryName', translations, id) ?? CategoriesName[id]
+
+      categoryPath = categoryPath.concat(`${translatedName}/`)
     })
 
     categories.push(categoryPath)
@@ -62,7 +74,10 @@ interface SpecificationInfo {
   [key: string]: any
 }
 
-const specificationsInfoFromDocument = (SpecificationGroups: SkuDocumentSpecificationGroup[]): SpecificationInfo => {
+const specificationsInfoFromDocument = (
+  SpecificationGroups: SkuDocumentSpecificationGroup[],
+  translations?: TranslatedProperty[]
+): SpecificationInfo => {
   const specificationsInfo: Record<string, any> = {}
   const specificationGroups: SpecificationGroup[] = []
   const properties: ProductProperty[] = []
@@ -85,9 +100,11 @@ const specificationsInfoFromDocument = (SpecificationGroups: SkuDocumentSpecific
 
     groupSpecs
       .map((specification) => ({
-        name: specification.Name,
-        originalName: specification.Name, // translate
-        values: specification.SpecificationValues.map((spec) => spec.Value), // translate
+        name: getTranslationInfo('SpecificationName', translations, specification.FieldId) ?? specification.Name,
+        originalName: specification.Name,
+        values: specification.SpecificationValues.map(
+          (spec) => getTranslationInfo('SpecificationValue', translations, spec.Id) ?? spec.Value
+        ),
       }))
       .forEach((spec) => properties.push(spec))
 
@@ -95,12 +112,14 @@ const specificationsInfoFromDocument = (SpecificationGroups: SkuDocumentSpecific
 
     if (visibleSpecs.length) {
       specificationGroups.push({
-        name: group.GroupName, // translate
+        name: group.GroupName,
         originalName: group.GroupName,
         specifications: visibleSpecs.map((specification) => ({
-          name: specification.Name,
+          name: getTranslationInfo('SpecificationName', translations, specification.FieldId) ?? specification.Name,
           originalName: specification.Name,
-          values: specification.SpecificationValues.map((spec) => spec.Value), // translate
+          values: specification.SpecificationValues.map(
+            (spec) => getTranslationInfo('SpecificationValue', translations, spec.Id) ?? spec.Value
+          ),
         })),
       })
     }
@@ -121,6 +140,46 @@ const specificationsInfoFromDocument = (SpecificationGroups: SkuDocumentSpecific
     specificationGroups,
     properties,
   }
+}
+
+const skuSpecificationsFromDocuments = (
+  allSpecGroups: SkuDocumentSpecificationGroup[][],
+  translations?: TranslatedProperty[]
+) => {
+  const skuSpecs: SkuDocumentSpecification[] = []
+  const groupedSpecs: Record<string, { Name: string; SpecificationValues: SkuDocumentSpecificationValue[] }> = {}
+
+  allSpecGroups.flat().forEach((specGroup) => {
+    const skuSpecsFromGroup = specGroup.Specifications.filter((spec) => spec.Field.IsStockKeppingUnit)
+
+    if (skuSpecsFromGroup.length) {
+      skuSpecs.push(...skuSpecsFromGroup)
+    }
+  })
+
+  skuSpecs.forEach((specification) => {
+    groupedSpecs[specification.FieldId] = {
+      Name: specification.Name,
+      SpecificationValues: (groupedSpecs[specification.FieldId]?.SpecificationValues ?? []).concat(
+        specification.SpecificationValues
+      ),
+    }
+  })
+
+  return Object.keys(groupedSpecs).map((key) => {
+    const item = groupedSpecs[key]
+
+    return {
+      field: {
+        name: getTranslationInfo('SpecificationName', translations, key) ?? item.Name,
+        originalName: item.Name,
+      },
+      values: item.SpecificationValues.map((value) => ({
+        name: getTranslationInfo('SpecificationValue', translations, value.Id) ?? value.Value,
+        originalName: value.Value,
+      })),
+    }
+  })
 }
 
 const getSpotPrice = (paymentOptions: PaymentOptions, priceWithoutDiscount: number) => {
@@ -256,7 +315,8 @@ const getSkuSubscriptions = (agregatedAttachments: SkuDocumentAttachment[]) =>
 
 const getSkuVariations = (
   specificationGroups: SkuDocumentSpecificationGroup[],
-  attachments: SkuDocumentAttachment[]
+  attachments: SkuDocumentAttachment[],
+  translations?: TranslatedProperty[]
 ) => {
   const attributes: Array<{
     key: string
@@ -275,10 +335,9 @@ const getSkuVariations = (
     filteredSpecs.forEach((spec) => {
       spec.SpecificationValues.forEach((value) => {
         attributes.push({
-          key: spec.Field.Name,
-          value: value.Value,
+          key: getTranslationInfo('SpecificationName', translations, spec.Field.Id.toString()) ?? spec.Field.Name,
+          value: getTranslationInfo('SpecificationValue', translations, value.Id) ?? value.Value,
         })
-        // translate (ver text_attributes)
       })
     })
   })
@@ -305,7 +364,12 @@ const getAttachments = (attachments: SkuDocumentAttachment[]): SearchAttachment[
   }))
 }
 
-export const itemsFromSearchDocuments = (documents: SkuDocument[], offers: SkuOffers, account: string) => {
+export const itemsFromSearchDocuments = (
+  documents: SkuDocument[],
+  offers: SkuOffers,
+  account: string,
+  translations?: TranslatedProperty[]
+) => {
   const items: SearchItem[] = []
 
   documents.forEach((skuDocument) => {
@@ -315,14 +379,17 @@ export const itemsFromSearchDocuments = (documents: SkuDocument[], offers: SkuOf
       return
     }
 
-    const variations = getSkuVariations(skuDocument.SpecificationGroups, skuDocument.AgregatedAttachments)
+    const variations = getSkuVariations(skuDocument.SpecificationGroups, skuDocument.AgregatedAttachments, translations)
     const images = convertDocumentImages(skuDocument.Images, account)
     const attachments = getAttachments(skuDocument.AgregatedAttachments)
+    const nameComplete = `${
+      getTranslationInfo('ProductName', translations, skuDocument.ProductId) ?? skuDocument.ProductName
+    } ${getTranslationInfo('SkuName', translations, skuDocument.Id) ?? skuDocument.Name}`
 
     const searchItem = {
       itemId: skuDocument.Id,
-      name: skuDocument.Name,
-      nameComplete: skuDocument.NameComplete,
+      name: getTranslationInfo('SkuName', translations, skuDocument.Id) ?? skuDocument.Name,
+      nameComplete,
       complementName: skuDocument.NameComplement,
       ean: skuDocument.AlternateIds.Ean ?? '',
       referenceId: [
@@ -340,7 +407,7 @@ export const itemsFromSearchDocuments = (documents: SkuDocument[], offers: SkuOf
       sellers: getSkuSellers(offer, skuDocument.UnitMultiplier),
       attachments,
       isKit: skuDocument.IsKit,
-      kitItems: [], // do we need to define this prop?
+      kitItems: [],
     }
 
     items.push(searchItem)
@@ -349,7 +416,12 @@ export const itemsFromSearchDocuments = (documents: SkuDocument[], offers: SkuOf
   return items
 }
 
-export const convertSearchDocument = async (documents: SkuDocument[], offers: SkuOffers, account: string) => {
+export const convertSearchDocument = async (
+  documents: SkuDocument[],
+  offers: SkuOffers,
+  account: string,
+  translations?: TranslatedProperty[]
+) => {
   const [
     {
       ProductId,
@@ -374,10 +446,14 @@ export const convertSearchDocument = async (documents: SkuDocument[], offers: Sk
 
   const searchableClusters = searchableClustersFromDocument(ProductClusterNames, ProductClusterSearchableIds)
 
-  const categories = categoriesFromDocument(CategoriesFullPath, CategoriesName)
-  // validar se só precisa pegar do primeiro item msm. talvez tenha que unir os itens
-  const specificationsInfo = specificationsInfoFromDocument(SpecificationGroups)
-  const items = itemsFromSearchDocuments(documents, offers, account)
+  const categories = categoriesFromDocument(CategoriesFullPath, CategoriesName, translations)
+  const specificationsInfo = specificationsInfoFromDocument(SpecificationGroups, translations)
+  const skuSpecifications = skuSpecificationsFromDocuments(
+    documents.map((document) => document.SpecificationGroups),
+    translations
+  )
+
+  const items = itemsFromSearchDocuments(documents, offers, account, translations)
 
   const product: SearchProduct & {
     cacheId?: string
@@ -386,14 +462,14 @@ export const convertSearchDocument = async (documents: SkuDocument[], offers: Sk
     categories,
     categoriesIds: CategoriesFullPath,
     productId: ProductId,
-    productName: ProductName,
+    productName: getTranslationInfo('ProductName', translations) ?? ProductName,
     cacheId: `sp-${ProductId}`,
     productReference: ProductRefId,
-    linkText: LinkId, // translate
-    brand: BrandName,
+    linkText: LinkId,
+    brand: getTranslationInfo('BrandName', translations) ?? BrandName,
     brandId: BrandId,
     link: `https://portal.vtexcommercestable.com.br/${LinkId}/p`,
-    description: Description,
+    description: getTranslationInfo('Description', translations) ?? Description,
     items,
     priceRange: getPriceRange(items),
     categoryId: DirectCategoryId.toString(),
@@ -403,8 +479,8 @@ export const convertSearchDocument = async (documents: SkuDocument[], offers: Sk
     productClusters: objToNameValue('id', 'name', ProductClusterNames),
     searchableClusters,
     titleTag: '',
-    categoryTree: [], // fix
-    skuSpecifications: [], // fix
+    categoryTree: [],
+    skuSpecifications,
     ...specificationsInfo,
     origin: 'search-document',
     releaseDate: ReleaseDate,

--- a/src/typings/global.ts
+++ b/src/typings/global.ts
@@ -887,4 +887,10 @@ declare global {
   }
 
   type IndexingType = 'API' | 'XML'
+
+  interface TranslatedProperty {
+    field: string
+    context: string
+    translation: string
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,3 +63,19 @@ export const getPriceRange = (searchItems: SearchItem[]) => {
 const TICKS_AT_EPOCH = 621355968000000000
 
 export const dateToTicks = (dateTime: string) => (new Date(dateTime)).getTime() * 10000 + TICKS_AT_EPOCH
+
+export const getTranslationInfo = (
+  info: string,
+  translationInfo?: Array<{ field: string; context: string; translation: string }>,
+  infoId?: string
+) => {
+  if (!translationInfo || !translationInfo.length) {
+    return undefined
+  }
+
+  const item = translationInfo.find((value) =>
+    infoId ? value.field === info && value.context === infoId : value.field === info
+  )
+
+  return item ? item.translation : undefined
+}


### PR DESCRIPTION
#### What problem is this solving?
Add translations for product query

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

Check if properties like product name, categories, description and also specifications are translated properly (this workspace should be translating to french)
[Workspace](https://thalyta--canali.myvtex.com/_v/api/intelligent-search/product?id=2837264&type=product.id&salesChannel=1)

<img width="936" alt="image" src="https://github.com/vtex/vtexis-compatibility-layer/assets/20840671/60fb4716-1cc5-4f0f-852e-f59991f85f9a">


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
