### PR TITLE
Fix product properties for PDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Product `properties` and `metaTagDescription` for PDP compatibility.
+
 ## [1.6.0] - 2024-03-05
 
 ### Added

--- a/src/__tests__/mock/documentTranslations.ts
+++ b/src/__tests__/mock/documentTranslations.ts
@@ -42,12 +42,12 @@ export const translationsMock: TranslatedProperty[] = [
   {
     field: 'SpecificationName',
     context: '30',
-    translation: 'Variant_Color',
+    translation: 'Condição do Produto',
   },
   {
     field: 'SpecificationValue',
     context: 'Roxo/Lilas',
-    translation: 'Purple',
+    translation: 'Novo',
   },
   {
     field: 'SkuName',

--- a/src/__tests__/mock/searchProduct.ts
+++ b/src/__tests__/mock/searchProduct.ts
@@ -27,17 +27,6 @@ export const searchProductMock: SearchProduct & {
   },
   specificationGroups: [
     {
-      name: 'Variantes',
-      originalName: 'Variantes',
-      specifications: [
-        {
-          name: 'Variante_Cor',
-          originalName: 'Variante_Cor',
-          values: ['Roxo/Lilas'],
-        },
-      ],
-    },
-    {
       name: 'Características do Produto',
       originalName: 'Características do Produto',
       specifications: [
@@ -68,11 +57,6 @@ export const searchProductMock: SearchProduct & {
       name: 'allSpecifications',
       originalName: 'allSpecifications',
       specifications: [
-        {
-          name: 'Variante_Cor',
-          originalName: 'Variante_Cor',
-          values: ['Roxo/Lilas'],
-        },
         {
           name: 'Condição do Produto',
           originalName: 'Condição do Produto',
@@ -122,11 +106,6 @@ export const searchProductMock: SearchProduct & {
     },
   ],
   properties: [
-    {
-      name: 'Variante_Cor',
-      originalName: 'Variante_Cor',
-      values: ['Roxo/Lilas'],
-    },
     {
       name: 'Condição do Produto',
       originalName: 'Condição do Produto',
@@ -248,6 +227,7 @@ export const searchProductMock: SearchProduct & {
           commertialOffer: {
             AvailableQuantity: 15,
             CacheVersionUsedToCallCheckout: '_',
+            GiftSkuIds: [],
             Installments: [
               {
                 InterestRate: 0,
@@ -944,6 +924,7 @@ export const searchProductMock: SearchProduct & {
             spotPrice: 2180,
             taxPercentage: 0,
             teasers: [],
+            DeliverySlaSamples: [],
           },
           sellerDefault: true,
           sellerId: '38900',
@@ -953,6 +934,7 @@ export const searchProductMock: SearchProduct & {
           addToCartLink:
             'https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=326782298&qty=1&seller=1&sc=1&price=0&cv=_&sc=1',
           commertialOffer: {
+            GiftSkuIds: [],
             AvailableQuantity: 0,
             CacheVersionUsedToCallCheckout: '_',
             Installments: [],
@@ -966,6 +948,7 @@ export const searchProductMock: SearchProduct & {
             spotPrice: 0,
             taxPercentage: 0,
             teasers: [],
+            DeliverySlaSamples: [],
           },
           sellerDefault: false,
           sellerId: '1',

--- a/src/__tests__/mock/vtexProduct.ts
+++ b/src/__tests__/mock/vtexProduct.ts
@@ -152,6 +152,8 @@ export const vtexProductMock: SearchProduct = {
             'https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=3&qty=1&seller=1&sc=1&price=37577&cv=7BC1384A9AE1193BA0E88BF2E10E208A_&sc=1',
           sellerDefault: true,
           commertialOffer: {
+            DeliverySlaSamples: [],
+            GiftSkuIds: [],
             discountHighlights: [],
             teasers: [
               {
@@ -417,6 +419,8 @@ export const vtexProductMock: SearchProduct = {
             'https://portal.vtexcommercestable.com.br/checkout/cart/add?sku=4&qty=1&seller=1&sc=1&price=60030&cv=7BC1384A9AE1193BA0E88BF2E10E208A_&sc=1',
           sellerDefault: true,
           commertialOffer: {
+            DeliverySlaSamples: [],
+            GiftSkuIds: [],
             discountHighlights: [],
             teasers: [
               {

--- a/src/typings/global.ts
+++ b/src/typings/global.ts
@@ -669,13 +669,13 @@ declare global {
     DeliverySlaSamplesPerRegion?: Record<string, { DeliverySlaPerTypes: any[]; Region: any | null }>
     Installments: SearchInstallment[]
     discountHighlights?: any[]
-    GiftSkuIds?: string[]
+    GiftSkuIds: string[]
     teasers: Teaser[]
     BuyTogether?: any[]
     ItemMetadataAttachment?: any[]
     spotPrice: number
     taxPercentage: number
-    DeliverySlaSamples?: Array<{
+    DeliverySlaSamples: Array<{
       DeliverySlaPerTypes: any[]
       Region: any | null
     }>


### PR DESCRIPTION
#### What problem is this solving?

We weren't filtering properties properly and adding the `metaTagDescription` fallback 

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://thalyta--canali.myvtex.com/_v/api/intelligent-search/product?id=2837264&type=product.id&salesChannel=1)
- check for metatagDescription property
- properties array should not contain `Clothing Size` since it has the flag `IsStockKeppingUnit` as true 

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
