### PR TITLE
Remove sku specs with no values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Remove specifications with no values from `skuSpecifications`.
+
 ## [1.6.1] - 2024-03-18
 
 ### Fixed

--- a/src/convertSearchDocument.ts
+++ b/src/convertSearchDocument.ts
@@ -153,6 +153,10 @@ const skuSpecificationsFromDocuments = (
   })
 
   skuSpecs.forEach((specification) => {
+    if (!specification.SpecificationValues.length) {
+      return
+    }
+
     groupedSpecs[specification.FieldId] = {
       Name: specification.Name,
       SpecificationValues: (groupedSpecs[specification.FieldId]?.SpecificationValues ?? []).concat(


### PR DESCRIPTION
#### What problem is this solving?

Stores that use the SkuSelector component in their PDP would show variations with no values 

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://thalyta1--storecomponents.myvtex.com/working-shirt/p?__bindingAddress=storetheme.vtex.com/)

#### Screenshots or example usage

Before:
<img width="1273" alt="Screenshot 2024-03-19 at 11 40 50 AM" src="https://github.com/vtex/vtexis-compatibility-layer/assets/20840671/f3120a13-6053-4283-b5db-7a6eacb519cb">

After:
<img width="1279" alt="Screenshot 2024-03-19 at 11 50 13 AM" src="https://github.com/vtex/vtexis-compatibility-layer/assets/20840671/7ffdbe0d-7d74-4a4d-9d6d-b8453f73efd9">


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
