### PR TITLE
Fix error when sku has no payment option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Error when sku offer has no payment option.
+
 ## [1.6.2] - 2024-03-20
 
 ### Fixed

--- a/src/convertSearchDocument.ts
+++ b/src/convertSearchDocument.ts
@@ -181,19 +181,19 @@ const skuSpecificationsFromDocuments = (
   })
 }
 
-const getSpotPrice = (paymentOptions: PaymentOptions, priceWithoutDiscount: number) => {
-  const installments = paymentOptions.InstallmentOptions.flatMap((option) => option.Installments)
-  const installment = installments.find(
+const getSpotPrice = (paymentOptions: PaymentOptions | null, priceWithoutDiscount: number) => {
+  const installments = paymentOptions?.InstallmentOptions.flatMap((option) => option.Installments)
+  const installment = installments?.find(
     (inst) => inst.Count && inst.ValueAsInt && inst.ValueAsInt / 100 < priceWithoutDiscount
   )
 
   return installment ? installment.ValueAsInt / 100 : priceWithoutDiscount
 }
 
-const buildInstallments = (paymentOptions: PaymentOptions, unitMultiplier: number): SearchInstallment[] => {
+const buildInstallments = (paymentOptions: PaymentOptions | null, unitMultiplier: number): SearchInstallment[] => {
   const installments: SearchInstallment[] = []
 
-  paymentOptions.InstallmentOptions.forEach((option) => {
+  paymentOptions?.InstallmentOptions.forEach((option) => {
     option.Installments.forEach((installment) => {
       installments.push({
         NumberOfInstallments: installment.Count,

--- a/src/typings/global.ts
+++ b/src/typings/global.ts
@@ -329,7 +329,7 @@ declare global {
     IsAvailable: boolean
     DeliverySlaSamples: any[]
     RatesAndBenefitsData: RatesAndBenefitsData | null
-    PaymentOptions: PaymentOptions
+    PaymentOptions: PaymentOptions | null
   }
 
   interface SkuOfferDetails {


### PR DESCRIPTION
#### What problem is this solving?

When the sku offer had no payment option, our API would return an error, and the page would be redirected to a not found page. Instead of that, we should return the product as unavailable.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[before](https://thalyta--lebiscuit.myvtex.com/notebook-samsung-book-intel-core-i3-windows-11-home-8gb-256gb-ssd-16v563u395570c33/p)
[after](https://thalyta1--lebiscuit.myvtex.com/notebook-samsung-book-intel-core-i3-windows-11-home-8gb-256gb-ssd-16v563u395570c33/p)

#### Screenshots or example usage

<img width="1418" alt="image" src="https://github.com/vtex/vtexis-compatibility-layer/assets/20840671/bedd9520-0682-49f1-b1b5-322368e36c8f">


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
