### PR TITLE
Fix error when SKU has no sellers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Error when SKU has no sellers.
+- Duplicated values for SKU specifications.
 
 ## [1.6.3] - 2024-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Error when SKU has no sellers.
+
 ## [1.6.3] - 2024-04-01
 
 ### Fixed

--- a/src/convertSearchDocument.ts
+++ b/src/convertSearchDocument.ts
@@ -93,7 +93,7 @@ const specificationsInfoFromDocument = (
     })
 
     groupSpecs
-      .filter((specification) => !specification.Field.IsStockKeppingUnit)
+      .filter((specification) => !specification.Field?.IsStockKeppingUnit)
       .map((specification) => ({
         name: getTranslationInfo('SpecificationName', translations, specification.FieldId) ?? specification.Name,
         originalName: specification.Name,
@@ -103,7 +103,7 @@ const specificationsInfoFromDocument = (
       }))
       .forEach((spec) => properties.push(spec))
 
-    const visibleSpecs = groupSpecs.filter((spec) => spec.IsOnProductDetails && !spec.Field.IsStockKeppingUnit)
+    const visibleSpecs = groupSpecs.filter((spec) => spec.IsOnProductDetails && !spec.Field?.IsStockKeppingUnit)
 
     if (visibleSpecs.length) {
       specificationGroups.push({
@@ -145,7 +145,7 @@ const skuSpecificationsFromDocuments = (
   const groupedSpecs: Record<string, { Name: string; SpecificationValues: SkuDocumentSpecificationValue[] }> = {}
 
   allSpecGroups.flat().forEach((specGroup) => {
-    const skuSpecsFromGroup = specGroup.Specifications.filter((spec) => spec.Field.IsStockKeppingUnit)
+    const skuSpecsFromGroup = specGroup.Specifications.filter((spec) => spec.Field?.IsStockKeppingUnit)
 
     if (skuSpecsFromGroup.length) {
       skuSpecs.push(...skuSpecsFromGroup)
@@ -295,14 +295,16 @@ const setDefaultSeller = (sellers: Array<Seller & { active: boolean }>): Seller[
 const getSkuSellers = (offer: SkuOfferDetails, unitMultiplier: number) => {
   const [salesChannel] = Object.keys(offer.SkuCommercialOfferPerSalesChannel)
 
-  const seller1: Seller & { active: boolean } = {
-    active: true,
-    sellerId: offer.Seller1.SellerId,
-    sellerName: offer.Seller1.Name,
-    sellerDefault: false,
-    addToCartLink: '', // fix
-    commertialOffer: buildCommercialOffer(offer.SkuCommercialOfferPerSalesChannel[salesChannel], unitMultiplier),
-  }
+  const seller1: (Seller & { active: boolean }) | null = offer.Seller1
+    ? {
+        active: true,
+        sellerId: offer.Seller1.SellerId,
+        sellerName: offer.Seller1.Name,
+        sellerDefault: false,
+        addToCartLink: '', // fix
+        commertialOffer: buildCommercialOffer(offer.SkuCommercialOfferPerSalesChannel[salesChannel], unitMultiplier),
+      }
+    : null
 
   const otherSellers: Array<Seller & { active: boolean }> = offer.SkuSellers.filter((seller) =>
     seller.AvailableSalesChannels.includes(Number(salesChannel))
@@ -317,7 +319,7 @@ const getSkuSellers = (offer: SkuOfferDetails, unitMultiplier: number) => {
     }
   })
 
-  return setDefaultSeller([seller1].concat(otherSellers))
+  return setDefaultSeller((seller1 ? [seller1] : []).concat(otherSellers))
 }
 
 const getSkuSubscriptions = (agregatedAttachments: SkuDocumentAttachment[]) =>
@@ -336,7 +338,7 @@ const getSkuVariations = (
   specificationGroups.forEach((group) => {
     const filteredSpecs = group.Specifications.filter(
       (specification) =>
-        specification.SpecificationValues.filter((spec) => spec.Value).length && specification.Field.IsStockKeppingUnit
+        specification.SpecificationValues.filter((spec) => spec.Value).length && specification.Field?.IsStockKeppingUnit
     ).map((specification) => ({
       ...specification,
       SpecificationValues: specification.SpecificationValues.filter((spec) => spec.Value),
@@ -345,7 +347,7 @@ const getSkuVariations = (
     filteredSpecs.forEach((spec) => {
       spec.SpecificationValues.forEach((value) => {
         attributes.push({
-          key: getTranslationInfo('SpecificationName', translations, spec.Field.Id.toString()) ?? spec.Field.Name,
+          key: getTranslationInfo('SpecificationName', translations, spec.Field!.Id.toString()) ?? spec.Field!.Name,
           value: getTranslationInfo('SpecificationValue', translations, value.Id) ?? value.Value,
         })
       })

--- a/src/convertSearchDocument.ts
+++ b/src/convertSearchDocument.ts
@@ -157,11 +157,15 @@ const skuSpecificationsFromDocuments = (
       return
     }
 
+    const currentSpecValues = groupedSpecs[specification.FieldId]?.SpecificationValues ?? []
+
+    const newSpecValues = specification.SpecificationValues.filter((specValue) => {
+      return currentSpecValues.findIndex((item) => item.Id === specValue.Id) === -1
+    })
+
     groupedSpecs[specification.FieldId] = {
       Name: specification.Name,
-      SpecificationValues: (groupedSpecs[specification.FieldId]?.SpecificationValues ?? []).concat(
-        specification.SpecificationValues
-      ),
+      SpecificationValues: currentSpecValues.concat(newSpecValues),
     }
   })
 

--- a/src/typings/global.ts
+++ b/src/typings/global.ts
@@ -494,7 +494,7 @@ declare global {
   }
 
   interface SkuDocumentSpecification {
-    Field: SkuDocumentSpecificationField
+    Field: SkuDocumentSpecificationField | null
     IsOnProductDetails: boolean
     FieldId: string
     Name: string


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
Fix errors when SKU has no sellers or if the `Field` value is `null`

#### How should this be manually tested?

[Workspace](https://thalyta--carrefourbr.myvtex.com/api/io/_v/api/intelligent-search/product?id=cabo-micro-usb-premium-dourado-easy-mobile-5448000&type=product.link)

[spec values](https://thalyta--totouy.myvtex.com/botadeportivaskechersjadehighreward15p/p?skuId=86250)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
