### PR TITLE
Add new deliveryPromisesBadges field to convertISProduct return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `deliveryPromisesBadges` field to search product
+
 ## [1.7.4] - 2025-03-13
 
 ### Removed

--- a/src/convertISProduct.ts
+++ b/src/convertISProduct.ts
@@ -243,6 +243,7 @@ export const convertISProduct = (product: BiggySearchProduct, tradePolicy?: stri
     categoryTree,
     rule: product.rule,
     releaseDate: product.release,
+    deliveryPromisesBadges: product.deliveryPromisesBadges
   }
 
   const specifications: DynamicKey<Specification> = {}

--- a/src/typings/global.ts
+++ b/src/typings/global.ts
@@ -54,6 +54,7 @@ declare global {
     priceText: string
     spotPriceText?: string
     rule?: Rule
+    deliveryPromisesBadges?: string[]
   }
 
   type Rule = {
@@ -536,6 +537,7 @@ declare global {
     skuSpecifications: SkuSpecification[]
     specificationGroups: SpecificationGroup[]
     priceRange: PriceRange
+    deliveryPromisesBadges?: string[]
   }
 
   interface SpecificationGroup {


### PR DESCRIPTION
#### What problem is this solving?

Added the new deliveryPromisesBadges field that we are going to use in the frontend to show the DP badges.
Related to this PR on sp-node: https://github.com/vtex/sp-node/pull/298

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [X] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [] Updated/created tests (important for bug fixes).
- [] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
