### PR TITLE
Feat: changing the DP badges type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Icon
 node_modules/
 lib/
 .eslintcache
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- `deliveryPromisesBadges` field to search product to allow objects instead of string
+
 ## [1.8.0] - 2025-05-05
 
 ### Added

--- a/src/convertISProduct.ts
+++ b/src/convertISProduct.ts
@@ -243,7 +243,7 @@ export const convertISProduct = (product: BiggySearchProduct, tradePolicy?: stri
     categoryTree,
     rule: product.rule,
     releaseDate: product.release,
-    deliveryPromisesBadges: product.deliveryPromisesBadges
+    deliveryPromisesBadges: product.deliveryPromisesBadges,
   }
 
   const specifications: DynamicKey<Specification> = {}

--- a/src/typings/global.ts
+++ b/src/typings/global.ts
@@ -54,7 +54,7 @@ declare global {
     priceText: string
     spotPriceText?: string
     rule?: Rule
-    deliveryPromisesBadges?: string[]
+    deliveryPromisesBadges?: object[]
   }
 
   type Rule = {
@@ -537,7 +537,7 @@ declare global {
     skuSpecifications: SkuSpecification[]
     specificationGroups: SpecificationGroup[]
     priceRange: PriceRange
-    deliveryPromisesBadges?: string[]
+    deliveryPromisesBadges?: object[]
   }
 
   interface SpecificationGroup {


### PR DESCRIPTION
#### What problem is this solving?
This aims to fix the type of the DP Badges so that it will allow to pass objects instead of strings.

#### How should this be manually tested?
This can't be manually tested on this PR but it's related to another two on IS API and on Biggy-Search projects

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [X] Updated `CHANGELOG.md`.
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes
This must be deployed before the IS API